### PR TITLE
ci: fix stale site (Jul 19) + daily-enrich rebase failures

### DIFF
--- a/.github/workflows/daily-enrich.yml
+++ b/.github/workflows/daily-enrich.yml
@@ -69,8 +69,29 @@ jobs:
           CHANGED=$(git diff --cached --name-only | wc -l | tr -d ' ')
           git commit -m "Daily enrich: GitHub metadata refresh ($(date -u '+%Y-%m-%d %H:%M UTC')) [${CHANGED} files]"
 
-          git pull --rebase origin "$GITHUB_REF_NAME" || git pull origin "$GITHUB_REF_NAME" --allow-unrelated-histories || {
-            echo "::error::Failed to pull latest changes before push"
-            exit 1
-          }
+          # Rebase the local commit onto the latest origin and push. The data
+          # workflows all touch output/libraries.json, so a concurrent run can
+          # land a commit mid-rebase and leave the tree conflicted. The old
+          # `|| git pull --allow-unrelated-histories` fallback can't recover
+          # from that (the tree is still mid-rebase), so the run died. This
+          # loop aborts a conflicted rebase cleanly, re-fetches, and retries.
+          OURS=$(git rev-parse HEAD)
+          ATTEMPTS=0
+          until git pull --rebase origin "$GITHUB_REF_NAME"; do
+            ATTEMPTS=$((ATTEMPTS + 1))
+            if [ "$ATTEMPTS" -gt 3 ]; then
+              echo "::error::Could not rebase $OURS onto origin/$GITHUB_REF_NAME after 3 attempts"
+              exit 1
+            fi
+            echo "::warning::Rebase conflicted (attempt $ATTEMPTS); resetting to origin and re-applying..."
+            git rebase --abort 2>/dev/null || true
+            git fetch origin "$GITHUB_REF_NAME"
+            git reset --hard "origin/$GITHUB_REF_NAME"
+            if ! git cherry-pick "$OURS"; then
+              # Generated-output conflict: prefer this run's output, then finish.
+              git checkout --theirs . 2>/dev/null || true
+              git add -A
+              GIT_EDITOR=true git cherry-pick --continue || git cherry-pick --abort
+            fi
+          done
           git push

--- a/.github/workflows/hourly-sync.yml
+++ b/.github/workflows/hourly-sync.yml
@@ -69,8 +69,29 @@ jobs:
           CHANGED=$(git diff --cached --name-only | wc -l | tr -d ' ')
           git commit -m "Hourly sync: update upstream library_index ($(date -u '+%Y-%m-%d %H:%M UTC')) [${CHANGED} files]"
 
-          git pull --rebase origin "$GITHUB_REF_NAME" || git pull origin "$GITHUB_REF_NAME" --allow-unrelated-histories || {
-            echo "::error::Failed to pull latest changes before push"
-            exit 1
-          }
+          # Rebase the local commit onto the latest origin and push. The data
+          # workflows all touch output/libraries.json, so a concurrent run can
+          # land a commit mid-rebase and leave the tree conflicted. The old
+          # `|| git pull --allow-unrelated-histories` fallback can't recover
+          # from that (the tree is still mid-rebase), so the run died. This
+          # loop aborts a conflicted rebase cleanly, re-fetches, and retries.
+          OURS=$(git rev-parse HEAD)
+          ATTEMPTS=0
+          until git pull --rebase origin "$GITHUB_REF_NAME"; do
+            ATTEMPTS=$((ATTEMPTS + 1))
+            if [ "$ATTEMPTS" -gt 3 ]; then
+              echo "::error::Could not rebase $OURS onto origin/$GITHUB_REF_NAME after 3 attempts"
+              exit 1
+            fi
+            echo "::warning::Rebase conflicted (attempt $ATTEMPTS); resetting to origin and re-applying..."
+            git rebase --abort 2>/dev/null || true
+            git fetch origin "$GITHUB_REF_NAME"
+            git reset --hard "origin/$GITHUB_REF_NAME"
+            if ! git cherry-pick "$OURS"; then
+              # Generated-output conflict: prefer this run's output, then finish.
+              git checkout --theirs . 2>/dev/null || true
+              git add -A
+              GIT_EDITOR=true git cherry-pick --continue || git cherry-pick --abort
+            fi
+          done
           git push

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,15 +1,26 @@
 name: Deploy GitHub Pages
 
-# Single trigger: push to main. The three data workflows (hourly-sync,
-# daily-enrich, weekly-stats) all commit and push to main on a change, so a
-# push-triggered deploy already covers them. Previously this also listened on
-# `workflow_run`, which fired a SECOND concurrent deploy on top of the
-# push deploy — the root cause of the recurring "transient Pages backend
-# failures" the retry chain was masking.
+# Triggers:
+#   push             — real (human/PAT) pushes to main. NOTE: pushes made with
+#                      the repo's default GITHUB_TOKEN do NOT fire the `push`
+#                      event, so this alone does not cover the data workflows
+#                      below (they all commit via GITHUB_TOKEN).
+#   workflow_run     — bridges that gap: fires when one of the three scheduled
+#                      data workflows (hourly-sync, daily-enrich, weekly-stats)
+#                      completes, so token-pushed data updates actually deploy.
+#
+# Earlier this also used workflow_run with `cancel-in-progress: false`, which
+# queued a SECOND deploy on top of the push deploy — the root cause of the
+# recurring "transient Pages backend failures". The concurrency group below
+# (with cancel-in-progress: true) now makes both triggers safe to keep.
 on:
   push:
     branches: [main]
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Hourly Sync (library_index.json.gz)", "Daily Enrichment (GitHub API + ETag)", "Weekly Stats Rollup"]
+    types: [completed]
+    branches: [main]
 
 concurrency:
   group: pages-${{ github.ref }}
@@ -24,6 +35,10 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # When triggered via workflow_run, only deploy if the upstream data
+    # workflow actually succeeded — a failed sync/enrich run shouldn't kick
+    # off a deploy. (Push and workflow_dispatch runs are unaffected.)
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/weekly-stats.yml
+++ b/.github/workflows/weekly-stats.yml
@@ -69,8 +69,29 @@ jobs:
           CHANGED=$(git diff --cached --name-only | wc -l | tr -d ' ')
           git commit -m "Weekly stats: rollup refresh ($(date -u '+%Y-%m-%d %H:%M UTC')) [${CHANGED} files]"
 
-          git pull --rebase origin "$GITHUB_REF_NAME" || git pull origin "$GITHUB_REF_NAME" --allow-unrelated-histories || {
-            echo "::error::Failed to pull latest changes before push"
-            exit 1
-          }
+          # Rebase the local commit onto the latest origin and push. The data
+          # workflows all touch output/libraries.json, so a concurrent run can
+          # land a commit mid-rebase and leave the tree conflicted. The old
+          # `|| git pull --allow-unrelated-histories` fallback can't recover
+          # from that (the tree is still mid-rebase), so the run died. This
+          # loop aborts a conflicted rebase cleanly, re-fetches, and retries.
+          OURS=$(git rev-parse HEAD)
+          ATTEMPTS=0
+          until git pull --rebase origin "$GITHUB_REF_NAME"; do
+            ATTEMPTS=$((ATTEMPTS + 1))
+            if [ "$ATTEMPTS" -gt 3 ]; then
+              echo "::error::Could not rebase $OURS onto origin/$GITHUB_REF_NAME after 3 attempts"
+              exit 1
+            fi
+            echo "::warning::Rebase conflicted (attempt $ATTEMPTS); resetting to origin and re-applying..."
+            git rebase --abort 2>/dev/null || true
+            git fetch origin "$GITHUB_REF_NAME"
+            git reset --hard "origin/$GITHUB_REF_NAME"
+            if ! git cherry-pick "$OURS"; then
+              # Generated-output conflict: prefer this run's output, then finish.
+              git checkout --theirs . 2>/dev/null || true
+              git add -A
+              GIT_EDITOR=true git cherry-pick --continue || git cherry-pick --abort
+            fi
+          done
           git push


### PR DESCRIPTION
## Why

The live site (thearduinolibrary.com) has been stuck at **2026-07-19** for 16 days, and the **Daily Enrichment** workflow has been failing ~3×/month with rebase conflicts. Two separate bugs, both fixed here.

## Problem 1 — site frozen at Jul 19 (the real issue)

`pages.yml` triggered only on `push: branches: [main]`. But the three data workflows (hourly-sync, daily-enrich, weekly-stats) all commit using the repository default **`GITHUB_TOKEN`**, and **pushes made with `GITHUB_TOKEN` do not fire the `push` event**. So:

- ✅ Hourly sync has run successfully every hour (last: today 15:45 UTC), updating `origin/main` through Aug 3.
- ❌ `pages.yml` last ran **2026-07-19**, triggered by the one human merge since launch. No deploy has fired since.

The ironic part: the comment in `pages.yml` explains `workflow_run` was *removed* to stop double-deploys. But that left no trigger that fires for token-pushes — so nothing deploys at all.

**Fix:** re-add `workflow_run` (types: `completed`) so the deploy fires when a data workflow finishes, plus a job-level guard so failed runs don't trigger a deploy. The old double-deploy problem is already prevented by the existing `concurrency: { cancel-in-progress: true }`.

## Problem 2 — Daily Enrichment rebase failures (the email noise)

Root cause from the Aug 4 failure log:
```
CONFLICT (content): Merge conflict in output/libraries.json
error: Pulling is not possible because you have unmerged files.
```

The fallback `git pull --rebase || git pull --allow-unrelated-histories` cannot recover from a rebase conflict — when `--rebase` conflicts, the tree stays mid-rebase and the `--allow-unrelated-histories` pull also fails. The run dies. Happens when an hourly-sync commit lands during a daily-enrich run (both touch `output/libraries.json`).

**Fix:** replace the broken one-liner with a retry loop that, on conflict, aborts the rebase cleanly, re-fetches origin, resets to origin, and re-applies our commit via `cherry-pick` (preferring this run's generated output), up to 3 attempts. Applied identically to all three data workflows.

## Changes
- `pages.yml` — add `workflow_run` trigger + `if:` guard for failed upstream runs
- `hourly-sync.yml`, `daily-enrich.yml`, `weekly-stats.yml` — conflict-recovering commit/push step

## Validation
- All 4 YAML files pass `yaml.safe_load`
- The commit/push script passes `bash -n`
- Recovery loop logic: captures commit SHA before rebase → on conflict aborts/fetch/resets/cherry-picks → bounded retries

## After merge
The next scheduled hourly sync (top of the hour) will push to main, complete successfully, and `workflow_run` will fire the deploy — the site should be live again within the hour.